### PR TITLE
Add JSON validation test for theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
         "revellion",
         "vscode",
         "dark"
-    ]
+    ],
+    "scripts": {
+        "test": "node test/validate-theme.js"
+    }
 }

--- a/test/validate-theme.js
+++ b/test/validate-theme.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const themePath = path.join(__dirname, '..', 'themes', 'Revellion Theme-color-theme.json');
+
+try {
+  const content = fs.readFileSync(themePath, 'utf8');
+  const json = JSON.parse(content);
+  if (json.name !== 'Revellion') {
+    console.error(`Expected name to be "Revellion" but got "${json.name}"`);
+    process.exitCode = 1;
+  } else {
+    console.log('Theme JSON is valid and contains expected name.');
+  }
+} catch (err) {
+  console.error('Failed to read or parse theme JSON:', err);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add `test/validate-theme.js` to check that the theme JSON parses correctly and has the expected name
- wire up npm `test` script to run the Node script

## Testing
- `npm test`