### PR TITLE
Normalize theme color codes to uppercase hex

### DIFF
--- a/themes/Revellion Theme-color-theme.json
+++ b/themes/Revellion Theme-color-theme.json
@@ -4,13 +4,13 @@
     "semanticHighlighting": true,
     "semanticTokenColors": {
         "enumMember": {
-            "foreground": "#fff"
+            "foreground": "#FFFFFF"
         },
         "variable.constant": {
-            "foreground": "#ff9b3d"
+            "foreground": "#FF9B3D"
         },
         "variable.defaultLibrary": {
-            "foreground": "#ffffff"
+            "foreground": "#FFFFFF"
         }
     },
     "tokenColors": [
@@ -18,182 +18,182 @@
             "name": "unison punctuation",
             "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "haskell variable generic-type",
             "scope": "variable.other.generic-type.haskell",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "haskell storage type",
             "scope": "storage.type.haskell",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "support.variable.magic.python",
             "scope": "support.variable.magic.python",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "punctuation.separator.parameters.python",
             "scope": "punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "variable.parameter.function.language.special.self.python",
             "scope": "variable.parameter.function.language.special.self.python",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "storage.modifier.lifetime.rust",
             "scope": "storage.modifier.lifetime.rust",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "support.function.std.rust",
             "scope": "support.function.std.rust",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "entity.name.lifetime.rust",
             "scope": "entity.name.lifetime.rust",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "variable.language.rust",
             "scope": "variable.language.rust",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "support.constant.edge",
             "scope": "support.constant.edge",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "regexp constant character-class",
             "scope": "constant.other.character-class.regexp",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "regexp operator.quantifier",
             "scope": "keyword.operator.quantifier.regexp",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "punctuation.definition",
             "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "Text",
             "scope": "variable.parameter.function",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Comment Markup Link",
             "scope": "comment markup.link",
             "settings": {
-                "foreground": "#4d4d4d"
+                "foreground": "#4D4D4D"
             }
         },
         {
             "name": "markup diff",
             "scope": "markup.changed.diff",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "diff",
             "scope": "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "inserted.diff",
             "scope": "markup.inserted.diff",
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "deleted.diff",
             "scope": "markup.deleted.diff",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "c++ function",
             "scope": "meta.function.c,meta.function.cpp",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "c++ block",
             "scope": "punctuation.section.block.begin.bracket.curly.cpp,punctuation.section.block.end.bracket.curly.cpp,punctuation.terminator.statement.c,punctuation.section.block.begin.bracket.curly.c,punctuation.section.block.end.bracket.curly.c,punctuation.section.parens.begin.bracket.round.c,punctuation.section.parens.end.bracket.round.c,punctuation.section.parameters.begin.bracket.round.c,punctuation.section.parameters.end.bracket.round.c",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "js/ts punctuation separator key-value",
             "scope": "punctuation.separator.key-value",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "js/ts import keyword",
             "scope": "keyword.operator.expression.import",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "math js/ts",
             "scope": "support.constant.math",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "math property js/ts",
             "scope": "support.constant.property.math",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
@@ -210,126 +210,126 @@
                 "storage.type.object.array.java"
             ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "java source",
             "scope": "source.java",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "java modifier.import",
             "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "java modifier.import",
             "scope": "meta.method.java",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "java modifier.import",
             "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "java instanceof",
             "scope": "keyword.operator.instanceof.java",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "java variable.name",
             "scope": "meta.definition.variable.name.java",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "operator logical",
             "scope": "keyword.operator.logical",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "operator bitwise",
             "scope": "keyword.operator.bitwise",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "operator channel",
             "scope": "keyword.operator.channel",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "support.constant.property-value.scss",
             "scope": "support.constant.property-value.scss,support.constant.property-value.css",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "CSS/SCSS/LESS Operators",
             "scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "css color standard name",
             "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "css comma",
             "scope": "punctuation.separator.list.comma.css",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "css attribute-name.id",
             "scope": "support.constant.color.w3c-standard-color-name.css",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "css property-name",
             "scope": "support.type.vendored.property-name.css",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "js/ts module",
             "scope": "support.module.node,support.type.object.module,support.module.node",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "entity.name.type.module",
             "scope": "entity.name.type.module",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
@@ -350,7 +350,7 @@
             "name": "",
             "scope": "meta.object-literal.key",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
@@ -370,238 +370,238 @@
                 "keyword.operator.expression.keyof"
             ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "js/ts console",
             "scope": "support.type.object.console",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "js/ts support.variable.property.process",
             "scope": "support.variable.property.process",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "js console function",
             "scope": "support.function.console",
             "settings": {
-                "foreground": "#d3438d"
+                "foreground": "#D3438D"
             }
         },
         {
             "name": "keyword.operator.misc.rust",
             "scope": "keyword.operator.misc.rust",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "keyword.operator.sigil.rust",
             "scope": "keyword.operator.sigil.rust",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "operator",
             "scope": "keyword.operator.delete",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "js dom",
             "scope": "support.type.object.dom",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "js dom variable",
             "scope": "support.variable.dom,support.variable.property.dom",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "keyword.operator",
             "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment,keyword.operator.relational",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "C operator assignment",
             "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.decrement.c,keyword.operator.bitwise.shift.c,keyword.operator.assignment.cpp,keyword.operator.comparison.cpp,keyword.operator.cpp,keyword.operator.increment.cpp,keyword.operator.decrement.cpp,keyword.operator.bitwise.shift.cpp",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Punctuation",
             "scope": "punctuation.separator.delimiter",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Other punctuation .c",
             "scope": "punctuation.separator.c,punctuation.separator.cpp",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "C type posix-reserved",
             "scope": "support.type.posix-reserved.c,support.type.posix-reserved.cpp",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "keyword.operator.sizeof.c",
             "scope": "keyword.operator.sizeof.c,keyword.operator.sizeof.cpp",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "python parameter",
             "scope": "variable.parameter.function.language.python",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "python type",
             "scope": "support.type.python",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "python logical",
             "scope": "keyword.operator.logical.python",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "pyCs",
             "scope": "variable.parameter.function.python",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "python block",
             "scope": "punctuation.definition.arguments.begin.python,punctuation.definition.arguments.end.python,punctuation.separator.arguments.python,punctuation.definition.list.begin.python,punctuation.definition.list.end.python",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "python function-call.generic",
             "scope": "meta.function-call.generic.python",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "python placeholder reset to normal string",
             "scope": "constant.character.format.placeholder.other.python",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Operators",
             "scope": "keyword.operator",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Compound Assignment Operators",
             "scope": "keyword.operator.assignment.compound",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Compound Assignment Operators js/ts",
             "scope": "keyword.operator.assignment.compound.js,keyword.operator.assignment.compound.ts",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Keywords",
             "scope": "keyword",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Namespaces",
             "scope": "entity.name.namespace",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Variables",
             "scope": "variable.c",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Language variables",
             "scope": "variable.language",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Java Variables",
             "scope": "token.variable.parameter.java",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Java Imports",
             "scope": "import.storage.java",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Packages",
             "scope": "token.package.keyword",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Packages",
             "scope": "token.package",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Classes",
             "scope": "entity.name.type.namespace",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
@@ -615,7 +615,7 @@
             "name": "Class name",
             "scope": "entity.name.class.identifier.namespace.type",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
@@ -626,154 +626,154 @@
                 "variable.other.class.ts"
             ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Class name php",
             "scope": "variable.other.class.php",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Type Name",
             "scope": "entity.name.type",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Keyword Control",
             "scope": "keyword.control",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Control Elements",
             "scope": "control.elements, keyword.operator.less",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Methods",
             "scope": "keyword.other.special-method",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "Storage",
             "scope": "storage",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Storage JS TS",
             "scope": "token.storage",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
             "scope": "keyword.operator.expression.delete,keyword.operator.expression.in,keyword.operator.expression.of,keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.expression.typeof,keyword.operator.expression.void",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Java Storage",
             "scope": "token.storage.type.java",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Support type",
             "scope": "support.type.property-name",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Support type",
             "scope": "support.constant.property-value",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Support type",
             "scope": "support.constant.font-name",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Strings",
             "scope": "string",
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "Inherited Class",
             "scope": "entity.other.inherited-class",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Constant other symbol",
             "scope": "constant.other.symbol",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Integers",
             "scope": "constant.numeric",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Constants",
             "scope": "constant",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Constants",
             "scope": "punctuation.definition.constant",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Tags",
             "scope": "entity.name.tag",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Attributes",
             "scope": "entity.other.attribute-name",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Attribute IDs",
             "scope": "entity.other.attribute-name.id",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
@@ -781,119 +781,119 @@
             "scope": "entity.other.attribute-name.class.css",
             "settings": {
                 "fontStyle": "normal",
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Selector",
             "scope": "meta.selector",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Headings",
             "scope": "markup.heading",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Headings",
             "scope": "markup.heading .definition.heading, entity.name.section",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "Units",
             "scope": "keyword.other.unit",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Bold",
             "scope": "markup.bold,todo.bold",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "Bold",
             "scope": ".definition.bold",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "markup Italic",
             "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "emphasis md",
             "scope": "emphasis md",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown headings",
             "scope": "entity.name.section.markdown",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
             "scope": "punctuation.definition.heading.markdown",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "punctuation.definition.list.begin.markdown",
             "scope": "punctuation.definition.list.begin.markdown",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown heading setext",
             "scope": "markup.heading.setext",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
             "scope": "punctuation.definition.bold.markdown",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
             "scope": "markup.inline.raw.markdown",
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
             "scope": "markup.inline.raw.string.markdown",
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
             "scope": "punctuation.definition.list.markdown",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
@@ -904,381 +904,383 @@
                 "punctuation.definition.metadata.markdown"
             ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "beginning.punctuation.definition.list.markdown",
-            "scope": ["beginning.punctuation.definition.list.markdown"],
+            "scope": [
+                "beginning.punctuation.definition.list.markdown"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
             "scope": "punctuation.definition.metadata.markdown",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
             "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
             "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "Regular Expressions",
             "scope": "string.regexp",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Escape Characters",
             "scope": "constant.character.escape",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Embedded",
             "scope": "punctuation.section.embedded, variable.interpolation",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Embedded",
             "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "illegal",
             "scope": "invalid.illegal",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "illegal",
             "scope": "invalid.illegal.bad-ampersand.html",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Broken",
             "scope": "invalid.broken",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Deprecated",
             "scope": "invalid.deprecated",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Unimplemented",
             "scope": "invalid.unimplemented",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Source Json Meta Structure Dictionary Json > String Quoted Json",
             "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Source Json Meta Structure Dictionary Json > String Quoted Json > Punctuation String",
             "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Source Json Meta Structure Dictionary Json > Value Json > String Quoted Json,source Json Meta Structure Array Json > Value Json > String Quoted Json,source Json Meta Structure Dictionary Json > Value Json > String Quoted Json > Punctuation,source Json Meta Structure Array Json > Value Json > String Quoted Json > Punctuation",
             "scope": "source.json meta.structure.dictionary.json > value.json > string.quoted.json,source.json meta.structure.array.json > value.json > string.quoted.json,source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation,source.json meta.structure.array.json > value.json > string.quoted.json > punctuation",
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "Source Json Meta Structure Dictionary Json > Constant Language Json,source Json Meta Structure Array Json > Constant Language Json",
             "scope": "source.json meta.structure.dictionary.json > constant.language.json,source.json meta.structure.array.json > constant.language.json",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "laravel blade tag",
             "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "laravel blade @",
             "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "use statement for other classes",
             "scope": "support.other.namespace.use.php,support.other.namespace.use-as.php,support.other.namespace.php,entity.other.alias.php,meta.interface.php",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "error suppression",
             "scope": "keyword.operator.error-control.php",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "php instanceof",
             "scope": "keyword.operator.type.php",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "style double quoted array index normal begin",
             "scope": "punctuation.section.array.begin.php",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "style double quoted array index normal end",
             "scope": "punctuation.section.array.end.php",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "php illegal.non-null-typehinted",
             "scope": "invalid.illegal.non-null-typehinted.php",
             "settings": {
-                "foreground": "#f44747"
+                "foreground": "#F44747"
             }
         },
         {
             "name": "storage",
             "scope": "storage",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "php types",
             "scope": "storage.type.php,meta.other.type.phpdoc.php,keyword.other.type.php,keyword.other.array.phpdoc.php",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "php call-function",
             "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "php function-resets",
             "scope": "punctuation.definition.parameters.begin.bracket.round.php,punctuation.definition.parameters.end.bracket.round.php,punctuation.separator.delimiter.php,punctuation.section.scope.begin.php,punctuation.section.scope.end.php,punctuation.terminator.expression.php,punctuation.definition.arguments.begin.bracket.round.php,punctuation.definition.arguments.end.bracket.round.php,punctuation.definition.storage-type.begin.bracket.round.php,punctuation.definition.storage-type.end.bracket.round.php,punctuation.definition.array.begin.bracket.round.php,punctuation.definition.array.end.bracket.round.php,punctuation.definition.begin.bracket.round.php,punctuation.definition.end.bracket.round.php,punctuation.definition.begin.bracket.curly.php,punctuation.definition.end.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php,punctuation.definition.section.switch-block.start.bracket.curly.php,punctuation.definition.section.switch-block.begin.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "support php constants",
             "scope": "support.constant.core.rust",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "support php constants",
             "scope": "support.constant.ext.php,support.constant.std.php,support.constant.core.php,support.constant.parser-token.php",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "php goto",
             "scope": "entity.name.goto-label.php,support.other.php",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "php logical/bitwise operator",
             "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "php regexp operator",
             "scope": "keyword.operator.regexp.php",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "php comparison",
             "scope": "keyword.operator.comparison.php",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "php heredoc/nowdoc",
             "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "python function decorator @",
             "scope": "meta.function.decorator.python",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "python function support",
             "scope": "support.token.decorator.python,meta.function.decorator.identifier.python",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "parameter function js/ts",
             "scope": "function.parameter",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "brace function",
             "scope": "function.brace",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "parameter function ruby cs",
             "scope": "function.parameter.ruby, function.parameter.cs",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "constant.language.symbol.ruby",
             "scope": "constant.language.symbol.ruby",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "rgb-value",
             "scope": "rgb-value",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "rgb value",
             "scope": "inline-color-decoration rgb-value",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "rgb value less",
             "scope": "less rgb-value",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "sass selector",
             "scope": "selector.sass",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "ts primitive/builtin types",
             "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "block scope",
             "scope": "block.scope.end,block.scope.begin",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "cs storage type",
             "scope": "storage.type.cs",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "cs local variable",
             "scope": "entity.name.variable.local.cs",
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "scope": "token.info-token",
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "scope": "token.warn-token",
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "scope": "token.error-token",
             "settings": {
-                "foreground": "#f44747"
+                "foreground": "#F44747"
             }
         },
         {
             "scope": "token.debug-token",
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
@@ -1289,91 +1291,115 @@
                 "punctuation.section.embedded"
             ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Reset JavaScript string interpolation expression",
-            "scope": ["meta.template.expression"],
+            "scope": [
+                "meta.template.expression"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Import module JS",
-            "scope": ["keyword.operator.module"],
+            "scope": [
+                "keyword.operator.module"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "js Flowtype",
-            "scope": ["support.type.type.flowtype"],
+            "scope": [
+                "support.type.type.flowtype"
+            ],
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "js Flow",
-            "scope": ["support.type.primitive"],
+            "scope": [
+                "support.type.primitive"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "js class prop",
-            "scope": ["meta.property.object"],
+            "scope": [
+                "meta.property.object"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "js func parameter",
-            "scope": ["variable.parameter.function.js"],
+            "scope": [
+                "variable.parameter.function.js"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "js template literals begin",
-            "scope": ["keyword.other.template.begin"],
+            "scope": [
+                "keyword.other.template.begin"
+            ],
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "js template literals end",
-            "scope": ["keyword.other.template.end"],
+            "scope": [
+                "keyword.other.template.end"
+            ],
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "js template literals variable braces begin",
-            "scope": ["keyword.other.substitution.begin"],
+            "scope": [
+                "keyword.other.substitution.begin"
+            ],
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "js template literals variable braces end",
-            "scope": ["keyword.other.substitution.end"],
+            "scope": [
+                "keyword.other.substitution.end"
+            ],
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "js operator.assignment",
-            "scope": ["keyword.operator.assignment"],
+            "scope": [
+                "keyword.operator.assignment"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "go operator",
-            "scope": ["keyword.operator.assignment.go"],
+            "scope": [
+                "keyword.operator.assignment.go"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
@@ -1383,42 +1409,52 @@
                 "keyword.operator.address.go"
             ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Go package name",
-            "scope": ["entity.name.package.go"],
+            "scope": [
+                "entity.name.package.go"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "elm prelude",
-            "scope": ["support.type.prelude.elm"],
+            "scope": [
+                "support.type.prelude.elm"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "elm constant",
-            "scope": ["support.constant.elm"],
+            "scope": [
+                "support.constant.elm"
+            ],
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "template literal",
-            "scope": ["punctuation.quasi.element"],
+            "scope": [
+                "punctuation.quasi.element"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "html/pug (jade) escaped characters and entities",
-            "scope": ["constant.character.entity"],
+            "scope": [
+                "constant.character.entity"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
@@ -1428,28 +1464,34 @@
                 "entity.other.attribute-name.pseudo-class"
             ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Clojure globals",
-            "scope": ["entity.global.clojure"],
+            "scope": [
+                "entity.global.clojure"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Clojure symbols",
-            "scope": ["meta.symbol.clojure"],
+            "scope": [
+                "meta.symbol.clojure"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Clojure constants",
-            "scope": ["constant.keyword.clojure"],
+            "scope": [
+                "constant.keyword.clojure"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
@@ -1459,63 +1501,79 @@
                 "variable.parameter.function.coffee"
             ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Ini Default Text",
-            "scope": ["source.ini"],
+            "scope": [
+                "source.ini"
+            ],
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "Makefile prerequisities",
-            "scope": ["meta.scope.prerequisites.makefile"],
+            "scope": [
+                "meta.scope.prerequisites.makefile"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Makefile text colour",
-            "scope": ["source.makefile"],
+            "scope": [
+                "source.makefile"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Groovy import names",
-            "scope": ["storage.modifier.import.groovy"],
+            "scope": [
+                "storage.modifier.import.groovy"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "Groovy Methods",
-            "scope": ["meta.method.groovy"],
+            "scope": [
+                "meta.method.groovy"
+            ],
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "Groovy Variables",
-            "scope": ["meta.definition.variable.name.groovy"],
+            "scope": [
+                "meta.definition.variable.name.groovy"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "Groovy Inheritance",
-            "scope": ["meta.definition.class.inherited.classes.groovy"],
+            "scope": [
+                "meta.definition.class.inherited.classes.groovy"
+            ],
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "HLSL Semantic",
-            "scope": ["support.variable.semantic.hlsl"],
+            "scope": [
+                "support.variable.semantic.hlsl"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
@@ -1529,112 +1587,144 @@
                 "support.type.object.hlsl"
             ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "SQL Variables",
-            "scope": ["text.variable", "text.bracketed"],
+            "scope": [
+                "text.variable",
+                "text.bracketed"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "types",
-            "scope": ["support.type.swift", "support.type.vb.asp"],
+            "scope": [
+                "support.type.swift",
+                "support.type.vb.asp"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "heading 1, keyword",
-            "scope": ["entity.name.function.xi"],
+            "scope": [
+                "entity.name.function.xi"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "heading 2, callable",
-            "scope": ["entity.name.class.xi"],
+            "scope": [
+                "entity.name.class.xi"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "heading 3, property",
-            "scope": ["constant.character.character-class.regexp.xi"],
+            "scope": [
+                "constant.character.character-class.regexp.xi"
+            ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "heading 4, type, class, interface",
-            "scope": ["constant.regexp.xi"],
+            "scope": [
+                "constant.regexp.xi"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "heading 5, enums, preprocessor, constant, decorator",
-            "scope": ["keyword.control.xi"],
+            "scope": [
+                "keyword.control.xi"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "heading 6, number",
-            "scope": ["invalid.xi"],
+            "scope": [
+                "invalid.xi"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "string",
-            "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
+            "scope": [
+                "beginning.punctuation.definition.quote.markdown.xi"
+            ],
             "settings": {
-                "foreground": "#81be24"
+                "foreground": "#81BE24"
             }
         },
         {
             "name": "comments",
-            "scope": ["beginning.punctuation.definition.list.markdown.xi"],
+            "scope": [
+                "beginning.punctuation.definition.list.markdown.xi"
+            ],
             "settings": {
-                "foreground": "#4d4d4d"
+                "foreground": "#4D4D4D"
             }
         },
         {
             "name": "link",
-            "scope": ["constant.character.xi"],
+            "scope": [
+                "constant.character.xi"
+            ],
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "accent",
-            "scope": ["accent.xi"],
+            "scope": [
+                "accent.xi"
+            ],
             "settings": {
-                "foreground": "#cd0a6f"
+                "foreground": "#CD0A6F"
             }
         },
         {
             "name": "wikiword",
-            "scope": ["wikiword.xi"],
+            "scope": [
+                "wikiword.xi"
+            ],
             "settings": {
-                "foreground": "#ff9b3d"
+                "foreground": "#FF9B3D"
             }
         },
         {
             "name": "language operators like '+', '-' etc",
-            "scope": ["constant.other.color.rgb-value.xi"],
+            "scope": [
+                "constant.other.color.rgb-value.xi"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
             "name": "elements to dim",
-            "scope": ["punctuation.definition.tag.xi"],
+            "scope": [
+                "punctuation.definition.tag.xi"
+            ],
             "settings": {
-                "foreground": "#4d4d4d"
+                "foreground": "#4D4D4D"
             }
         },
         {
@@ -1645,7 +1735,7 @@
                 "entity.name.scope-resolution.function.definition"
             ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
@@ -1656,14 +1746,16 @@
                 "markup.heading.setext.2.markdown"
             ],
             "settings": {
-                "foreground": "#00abff"
+                "foreground": "#00ABFF"
             }
         },
         {
             "name": "meta.brace.square",
-            "scope": [" meta.brace.square"],
+            "scope": [
+                " meta.brace.square"
+            ],
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
@@ -1671,27 +1763,29 @@
             "scope": "comment, punctuation.definition.comment",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#4d4d4d"
+                "foreground": "#4D4D4D"
             }
         },
         {
             "name": "[VSCODE-CUSTOM] Markdown Quote",
             "scope": "markup.quote.markdown",
             "settings": {
-                "foreground": "#4d4d4d"
+                "foreground": "#4D4D4D"
             }
         },
         {
             "name": "punctuation.definition.block.sequence.item.yaml",
             "scope": "punctuation.definition.block.sequence.item.yaml",
             "settings": {
-                "foreground": "#ffffff"
+                "foreground": "#FFFFFF"
             }
         },
         {
-            "scope": ["constant.language.symbol.elixir"],
+            "scope": [
+                "constant.language.symbol.elixir"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
@@ -1699,7 +1793,7 @@
             "scope": "entity.other.attribute-name.js,entity.other.attribute-name.ts,entity.other.attribute-name.jsx,entity.other.attribute-name.tsx,variable.parameter,variable.language.super",
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
@@ -1739,7 +1833,7 @@
                 "source.json meta.structure.dictionary.json support.type.property-name.json"
             ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
@@ -1748,7 +1842,7 @@
                 "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
             ],
             "settings": {
-                "foreground": "#f8b842"
+                "foreground": "#F8B842"
             }
         },
         {
@@ -1793,7 +1887,7 @@
                 "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
             ],
             "settings": {
-                "foreground": "#f07178"
+                "foreground": "#F07178"
             }
         },
         {
@@ -1802,7 +1896,7 @@
                 "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json support.type.property-name.json"
             ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
@@ -1826,9 +1920,11 @@
         },
         {
             "name": "Markdown - Markup Raw Inline",
-            "scope": ["text.html.markdown markup.inline.raw.markdown"],
+            "scope": [
+                "text.html.markdown markup.inline.raw.markdown"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
@@ -1853,18 +1949,23 @@
         },
         {
             "name": "Markup - Italic",
-            "scope": ["markup.italic"],
+            "scope": [
+                "markup.italic"
+            ],
             "settings": {
                 "fontStyle": "italic",
-                "foreground": "#f07178"
+                "foreground": "#F07178"
             }
         },
         {
             "name": "Markup - Bold",
-            "scope": ["markup.bold", "markup.bold string"],
+            "scope": [
+                "markup.bold",
+                "markup.bold string"
+            ],
             "settings": {
                 "fontStyle": "bold",
-                "foreground": "#f07178"
+                "foreground": "#F07178"
             }
         },
         {
@@ -1879,12 +1980,14 @@
             ],
             "settings": {
                 "fontStyle": "bold",
-                "foreground": "#f07178"
+                "foreground": "#F07178"
             }
         },
         {
             "name": "Markup - Underline",
-            "scope": ["markup.underline"],
+            "scope": [
+                "markup.underline"
+            ],
             "settings": {
                 "fontStyle": "underline",
                 "foreground": "#F78C6C"
@@ -1901,49 +2004,63 @@
         },
         {
             "name": "Markup - Quote",
-            "scope": ["markup.quote"],
+            "scope": [
+                "markup.quote"
+            ],
             "settings": {
                 "fontStyle": "italic"
             }
         },
         {
             "name": "Markdown - Link",
-            "scope": ["string.other.link.title.markdown"],
+            "scope": [
+                "string.other.link.title.markdown"
+            ],
             "settings": {
                 "foreground": "#82AAFF"
             }
         },
         {
             "name": "Markdown - Link Description",
-            "scope": ["string.other.link.description.title.markdown"],
+            "scope": [
+                "string.other.link.description.title.markdown"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Markdown - Link Anchor",
-            "scope": ["constant.other.reference.link.markdown"],
+            "scope": [
+                "constant.other.reference.link.markdown"
+            ],
             "settings": {
-                "foreground": "#f8b842"
+                "foreground": "#F8B842"
             }
         },
         {
             "name": "Markup - Raw Block",
-            "scope": ["markup.raw.block"],
+            "scope": [
+                "markup.raw.block"
+            ],
             "settings": {
-                "foreground": "#c785db"
+                "foreground": "#C785DB"
             }
         },
         {
             "name": "Markdown - Raw Block Fenced",
-            "scope": ["markup.raw.block.fenced.markdown"],
+            "scope": [
+                "markup.raw.block.fenced.markdown"
+            ],
             "settings": {
                 "foreground": "#00000050"
             }
         },
         {
             "name": "Markdown - Fenced Bode Block",
-            "scope": ["punctuation.definition.fenced.markdown"],
+            "scope": [
+                "punctuation.definition.fenced.markdown"
+            ],
             "settings": {
                 "foreground": "#00000050"
             }
@@ -1961,14 +2078,18 @@
         },
         {
             "name": "Markdown - Fenced Language",
-            "scope": ["variable.language.fenced.markdown"],
+            "scope": [
+                "variable.language.fenced.markdown"
+            ],
             "settings": {
                 "foreground": "#65737E"
             }
         },
         {
             "name": "Markdown - Separator",
-            "scope": ["meta.separator"],
+            "scope": [
+                "meta.separator"
+            ],
             "settings": {
                 "fontStyle": "bold",
                 "foreground": "#65737E"
@@ -1976,268 +2097,271 @@
         },
         {
             "name": "Markup - Table",
-            "scope": ["markup.table"],
+            "scope": [
+                "markup.table"
+            ],
             "settings": {
                 "foreground": "#EEFFFF"
             }
         },
         {
             "name": "Markup - Table Header",
-            "scope": ["markup.table.header"],
+            "scope": [
+                "markup.table.header"
+            ],
             "settings": {
                 "foreground": "#C3E88D"
             }
         }
     ],
     "colors": {
-        
-        "foreground": "#ececec",
-        "focusBorder": "#007fd4",
-        "selection.background": "#256aa7",
+        "foreground": "#ECECEC",
+        "focusBorder": "#007FD4",
+        "selection.background": "#256AA7",
         "scrollbar.shadow": "#000000",
-        "activityBar.foreground": "#81be24",
-        "activityBar.background": "#0c1633",
-        "activityBar.inactiveForeground": "#ffffff66",
-        "activityBarBadge.foreground": "#ffffff",
-        "activityBarBadge.background": "#c785db",
-        "sideBar.background": "#03091e",
-        "sideBar.foreground": "#cccccc",
-        "sideBarSectionHeader.background": "#03091e",
-        "sideBarSectionHeader.foreground": "#cccccc",
-        "sideBarSectionHeader.border": "#cccccc0e",
-        "sideBarTitle.foreground": "#9d9d9d",
-        "sideBar.border": "#03091e",
-        "list.inactiveSelectionBackground": "#0c1633",
-        "list.inactiveSelectionForeground": "#cccccc",
-        "list.hoverBackground": "#0c1633",
-        "list.hoverForeground": "#cccccc",
-        "list.activeSelectionBackground": "#0c1633",
-        "list.activeSelectionForeground": "#ffffff",
+        "activityBar.foreground": "#81BE24",
+        "activityBar.background": "#0C1633",
+        "activityBar.inactiveForeground": "#FFFFFF66",
+        "activityBarBadge.foreground": "#FFFFFF",
+        "activityBarBadge.background": "#C785DB",
+        "sideBar.background": "#03091E",
+        "sideBar.foreground": "#CCCCCC",
+        "sideBarSectionHeader.background": "#03091E",
+        "sideBarSectionHeader.foreground": "#CCCCCC",
+        "sideBarSectionHeader.border": "#CCCCCC0E",
+        "sideBarTitle.foreground": "#9D9D9D",
+        "sideBar.border": "#03091E",
+        "list.inactiveSelectionBackground": "#0C1633",
+        "list.inactiveSelectionForeground": "#CCCCCC",
+        "list.hoverBackground": "#0C1633",
+        "list.hoverForeground": "#CCCCCC",
+        "list.activeSelectionBackground": "#0C1633",
+        "list.activeSelectionForeground": "#FFFFFF",
         "tree.indentGuidesStroke": "#585858",
-        "list.dropBackground": "#383b3d",
-        "list.highlightForeground": "#0097fb",
-        "list.focusBackground": "#062f4a",
-        "list.focusForeground": "#cccccc",
+        "list.dropBackground": "#383B3D",
+        "list.highlightForeground": "#0097FB",
+        "list.focusBackground": "#062F4A",
+        "list.focusForeground": "#CCCCCC",
         "listFilterWidget.background": "#653723",
         "listFilterWidget.outline": "#00000000",
-        "listFilterWidget.noMatchesOutline": "#be1100",
-        "statusBar.foreground": "#03091e",
-        "statusBar.background": "#81be24",
-        "statusBarItem.hoverBackground": "#ffffff1f",
-        "statusBar.debuggingBackground": "#cc6633",
-        "statusBar.debuggingForeground": "#ffffff",
-        "statusBar.noFolderBackground": "#6f9928",
-        "statusBar.noFolderForeground": "#03091e",
-        "statusBarItem.remoteBackground": "#81be24",
-        "statusBarItem.remoteForeground": "#03091e",
-        "titleBar.activeBackground": "#03091e",
-        "titleBar.activeForeground": "#ffffff",
-        "titleBar.inactiveBackground": "#03091ea3",
-        "titleBar.inactiveForeground": "#cccccc99",
+        "listFilterWidget.noMatchesOutline": "#BE1100",
+        "statusBar.foreground": "#03091E",
+        "statusBar.background": "#81BE24",
+        "statusBarItem.hoverBackground": "#FFFFFF1F",
+        "statusBar.debuggingBackground": "#CC6633",
+        "statusBar.debuggingForeground": "#FFFFFF",
+        "statusBar.noFolderBackground": "#6F9928",
+        "statusBar.noFolderForeground": "#03091E",
+        "statusBarItem.remoteBackground": "#81BE24",
+        "statusBarItem.remoteForeground": "#03091E",
+        "titleBar.activeBackground": "#03091E",
+        "titleBar.activeForeground": "#FFFFFF",
+        "titleBar.inactiveBackground": "#03091EA3",
+        "titleBar.inactiveForeground": "#CCCCCC99",
         "titleBar.border": "#00000000",
-        "menubar.selectionForeground": "#ffffff",
-        "menubar.selectionBackground": "#ffffff1a",
-        "menu.foreground": "#cccccc",
-        "menu.background": "#03091e",
-        "menu.selectionForeground": "#ffffff",
-        "menu.selectionBackground": "#0c1633",
+        "menubar.selectionForeground": "#FFFFFF",
+        "menubar.selectionBackground": "#FFFFFF1A",
+        "menu.foreground": "#CCCCCC",
+        "menu.background": "#03091E",
+        "menu.selectionForeground": "#FFFFFF",
+        "menu.selectionBackground": "#0C1633",
         "menu.selectionBorder": "#00000000",
         "menu.separatorBackground": "#968181",
         "menu.border": "#00000085",
-        "button.background": "#0e639c",
-        "button.foreground": "#ffffff",
-        "button.hoverBackground": "#1177bb",
-        "button.secondaryForeground": "#ffffff",
-        "button.secondaryBackground": "#3a3d41",
-        "button.secondaryHoverBackground": "#45494e",
-        "input.background": "#0c1633",
+        "button.background": "#0E639C",
+        "button.foreground": "#FFFFFF",
+        "button.hoverBackground": "#1177BB",
+        "button.secondaryForeground": "#FFFFFF",
+        "button.secondaryBackground": "#3A3D41",
+        "button.secondaryHoverBackground": "#45494E",
+        "input.background": "#0C1633",
         "input.border": "#00000000",
-        "input.foreground": "#cccccc",
-        "inputOption.activeBackground": "#007fd466",
-        "inputOption.activeBorder": "#007acc00",
-        "inputOption.activeForeground": "#ffffff",
-        "input.placeholderForeground": "#a6a6a6",
-        "textLink.foreground": "#3794ff",
-        "editor.background": "#03091e",
-        "editor.foreground": "#ffffff",
-        "editorLineNumber.foreground": "#b8b8b8",
-        "editorCursor.foreground": "#ffffff",
-        "editorCursor.background": "#03091e",
-        "editor.selectionBackground": "#264f78",
-        "editor.inactiveSelectionBackground": "#0a1e64a1",
-        "editorWhitespace.foreground": "#e3e4e229",
-        "editor.selectionHighlightBackground": "#add6ff26",
+        "input.foreground": "#CCCCCC",
+        "inputOption.activeBackground": "#007FD466",
+        "inputOption.activeBorder": "#007ACC00",
+        "inputOption.activeForeground": "#FFFFFF",
+        "input.placeholderForeground": "#A6A6A6",
+        "textLink.foreground": "#3794FF",
+        "editor.background": "#03091E",
+        "editor.foreground": "#FFFFFF",
+        "editorLineNumber.foreground": "#B8B8B8",
+        "editorCursor.foreground": "#FFFFFF",
+        "editorCursor.background": "#03091E",
+        "editor.selectionBackground": "#264F78",
+        "editor.inactiveSelectionBackground": "#0A1E64A1",
+        "editorWhitespace.foreground": "#E3E4E229",
+        "editor.selectionHighlightBackground": "#ADD6FF26",
         "editor.selectionHighlightBorder": "#495F77",
-        "editor.findMatchBackground": "#8098b6",
-        "editor.findMatchBorder": "#74879f",
-        "editor.findMatchHighlightBackground": "#ea5c0055",
-        "editor.findMatchHighlightBorder": "#ffffff00",
-        "editor.findRangeHighlightBackground": "#3a3d4166",
-        "editor.findRangeHighlightBorder": "#ffffff00",
-        "editor.rangeHighlightBackground": "#ffffff0b",
-        "editor.rangeHighlightBorder": "#ffffff00",
-        "editor.hoverHighlightBackground": "#264f7840",
-        "editor.wordHighlightStrongBackground": "#004972b8",
-        "editor.wordHighlightBackground": "#575757b8",
-        "editor.lineHighlightBackground": "#ffffff0A",
+        "editor.findMatchBackground": "#8098B6",
+        "editor.findMatchBorder": "#74879F",
+        "editor.findMatchHighlightBackground": "#EA5C0055",
+        "editor.findMatchHighlightBorder": "#FFFFFF00",
+        "editor.findRangeHighlightBackground": "#3A3D4166",
+        "editor.findRangeHighlightBorder": "#FFFFFF00",
+        "editor.rangeHighlightBackground": "#FFFFFF0B",
+        "editor.rangeHighlightBorder": "#FFFFFF00",
+        "editor.hoverHighlightBackground": "#264F7840",
+        "editor.wordHighlightStrongBackground": "#004972B8",
+        "editor.wordHighlightBackground": "#575757B8",
+        "editor.lineHighlightBackground": "#FFFFFF0A",
         "editor.lineHighlightBorder": "#282828",
-        "editorLineNumber.activeForeground": "#c6c6c6",
-        "editorLink.activeForeground": "#4e94ce",
+        "editorLineNumber.activeForeground": "#C6C6C6",
+        "editorLink.activeForeground": "#4E94CE",
         "editorIndentGuide.background": "#404040",
         "editorIndentGuide.activeBackground": "#707070",
-        "editorRuler.foreground": "#5a5a5a",
-        "editorBracketMatch.background": "#0064001a",
+        "editorRuler.foreground": "#5A5A5A",
+        "editorBracketMatch.background": "#0064001A",
         "editorBracketMatch.border": "#888888",
-        "editor.foldBackground": "#264f784d",
+        "editor.foldBackground": "#264F784D",
         "editorOverviewRuler.background": "#25252500",
-        "editorOverviewRuler.border": "#7f7f7f4d",
+        "editorOverviewRuler.border": "#7F7F7F4D",
         "editorError.foreground": "#B73A34",
         "editorError.background": "#B73A3400",
-        "editorError.border": "#ffffff00",
-        "editorWarning.foreground": "#cca700",
+        "editorError.border": "#FFFFFF00",
+        "editorWarning.foreground": "#CCA700",
         "editorWarning.background": "#A9904000",
-        "editorWarning.border": "#ffffff00",
-        "editorInfo.foreground": "#75beff",
+        "editorWarning.border": "#FFFFFF00",
+        "editorInfo.foreground": "#75BEFF",
         "editorInfo.background": "#4490BF00",
         "editorInfo.border": "#4490BF00",
-        "editorGutter.background": "#03091e",
-        "editorGutter.modifiedBackground": "#0c7d9d",
-        "editorGutter.addedBackground": "#587c0c",
-        "editorGutter.deletedBackground": "#94151b",
-        "editorGutter.foldingControlForeground": "#c5c5c5",
-        "editorCodeLens.foreground": "#ff5cb8",
+        "editorGutter.background": "#03091E",
+        "editorGutter.modifiedBackground": "#0C7D9D",
+        "editorGutter.addedBackground": "#587C0C",
+        "editorGutter.deletedBackground": "#94151B",
+        "editorGutter.foldingControlForeground": "#C5C5C5",
+        "editorCodeLens.foreground": "#FF5CB8",
         "editorGroup.border": "#444444",
         "diffEditor.insertedTextBackground": "#00BAFF1F",
-        "diffEditor.removedTextBackground": "#ff000033",
+        "diffEditor.removedTextBackground": "#FF000033",
         "diffEditor.border": "#444444",
-        "panel.background": "#03091e",
-        "panel.border": "#888888b3",
-        "panelTitle.activeBorder": "#e7e7e7",
-        "panelTitle.activeForeground": "#e7e7e7",
-        "panelTitle.inactiveForeground": "#e7e7e799",
-        "badge.background": "#4d4d4d",
-        "badge.foreground": "#ffffff",
-        "terminal.foreground": "#cccccc",
-        "terminal.selectionBackground": "#ffffff40",
-        "terminalCursor.background": "#0b3e6b",
-        "terminalCursor.foreground": "#ffffff",
+        "panel.background": "#03091E",
+        "panel.border": "#888888B3",
+        "panelTitle.activeBorder": "#E7E7E7",
+        "panelTitle.activeForeground": "#E7E7E7",
+        "panelTitle.inactiveForeground": "#E7E7E799",
+        "badge.background": "#4D4D4D",
+        "badge.foreground": "#FFFFFF",
+        "terminal.foreground": "#CCCCCC",
+        "terminal.selectionBackground": "#FFFFFF40",
+        "terminalCursor.background": "#0B3E6B",
+        "terminalCursor.foreground": "#FFFFFF",
         "terminal.border": "#80808059",
         "terminal.ansiBlack": "#000000",
-        "terminal.ansiBlue": "#2472c8",
+        "terminal.ansiBlue": "#2472C8",
         "terminal.ansiBrightBlack": "#666666",
-        "terminal.ansiBrightBlue": "#3b8eea",
-        "terminal.ansiBrightCyan": "#29b8db",
-        "terminal.ansiBrightGreen": "#23d18b",
-        "terminal.ansiBrightMagenta": "#d670d6",
-        "terminal.ansiBrightRed": "#f14c4c",
-        "terminal.ansiBrightWhite": "#e5e5e5",
-        "terminal.ansiBrightYellow": "#f5f543",
-        "terminal.ansiCyan": "#11a8cd",
-        "terminal.ansiGreen": "#0dbc79",
-        "terminal.ansiMagenta": "#bc3fbc",
-        "terminal.ansiRed": "#cd3131",
-        "terminal.ansiWhite": "#e5e5e5",
-        "terminal.ansiYellow": "#e5e510",
-        "breadcrumb.background": "#0c1633",
-        "breadcrumb.foreground": "#cccccccc",
-        "breadcrumb.focusForeground": "#e0e0e0",
-        "editorGroupHeader.tabsBackground": "#03091e",
-        "tab.activeForeground": "#ababab",
+        "terminal.ansiBrightBlue": "#3B8EEA",
+        "terminal.ansiBrightCyan": "#29B8DB",
+        "terminal.ansiBrightGreen": "#23D18B",
+        "terminal.ansiBrightMagenta": "#D670D6",
+        "terminal.ansiBrightRed": "#F14C4C",
+        "terminal.ansiBrightWhite": "#E5E5E5",
+        "terminal.ansiBrightYellow": "#F5F543",
+        "terminal.ansiCyan": "#11A8CD",
+        "terminal.ansiGreen": "#0DBC79",
+        "terminal.ansiMagenta": "#BC3FBC",
+        "terminal.ansiRed": "#CD3131",
+        "terminal.ansiWhite": "#E5E5E5",
+        "terminal.ansiYellow": "#E5E510",
+        "breadcrumb.background": "#0C1633",
+        "breadcrumb.foreground": "#CCCCCCCC",
+        "breadcrumb.focusForeground": "#E0E0E0",
+        "editorGroupHeader.tabsBackground": "#03091E",
+        "tab.activeForeground": "#ABABAB",
         "tab.border": "#282828",
-        "tab.activeBackground": "#0c1633",
+        "tab.activeBackground": "#0C1633",
         "tab.activeBorder": "#00000000",
         "tab.activeBorderTop": "#00000000",
-        "tab.inactiveBackground": "#03091e",
-        "tab.inactiveForeground": "#ababab",
-        "tab.hoverBackground": "#0c1633",
-        "scrollbarSlider.background": "#0c16337a",
-        "scrollbarSlider.hoverBackground": "#0c1633b1",
-        "scrollbarSlider.activeBackground": "#bfbfbf66",
-        "progressBar.background": "#0e70c0",
-        "widget.shadow": "#0000005c",
-        "editorWidget.foreground": "#cccccc",
-        "editorWidget.background": "#09091b",
-        "editorWidget.resizeBorder": "#bababa",
-        "pickerGroup.border": "#7d7d7d",
-        "pickerGroup.foreground": "#3794ff",
-        "debugToolBar.background": "#151a28",
+        "tab.inactiveBackground": "#03091E",
+        "tab.inactiveForeground": "#ABABAB",
+        "tab.hoverBackground": "#0C1633",
+        "scrollbarSlider.background": "#0C16337A",
+        "scrollbarSlider.hoverBackground": "#0C1633B1",
+        "scrollbarSlider.activeBackground": "#BFBFBF66",
+        "progressBar.background": "#0E70C0",
+        "widget.shadow": "#0000005C",
+        "editorWidget.foreground": "#CCCCCC",
+        "editorWidget.background": "#09091B",
+        "editorWidget.resizeBorder": "#BABABA",
+        "pickerGroup.border": "#7D7D7D",
+        "pickerGroup.foreground": "#3794FF",
+        "debugToolBar.background": "#151A28",
         "debugToolBar.border": "#808080",
-        "notifications.foreground": "#cccccc",
-        "notifications.background": "#03091e",
-        "notificationToast.border": "#343434f3",
-        "notificationsErrorIcon.foreground": "#fb775d",
-        "notificationsWarningIcon.foreground": "#cca700",
-        "notificationsInfoIcon.foreground": "#0a8ecd",
+        "notifications.foreground": "#CCCCCC",
+        "notifications.background": "#03091E",
+        "notificationToast.border": "#343434F3",
+        "notificationsErrorIcon.foreground": "#FB775D",
+        "notificationsWarningIcon.foreground": "#CCA700",
+        "notificationsInfoIcon.foreground": "#0A8ECD",
         "notificationCenter.border": "#474747",
-        "notificationCenterHeader.foreground": "#cccccc",
-        "notificationCenterHeader.background": "#0c1633",
+        "notificationCenterHeader.foreground": "#CCCCCC",
+        "notificationCenterHeader.background": "#0C1633",
         "notifications.border": "#303031",
-        "gitDecoration.addedResourceForeground": "#ffffff",
-        "gitDecoration.conflictingResourceForeground": "#6c6cc4",
-        "gitDecoration.deletedResourceForeground": "#c74e39",
-        "gitDecoration.ignoredResourceForeground": "#8c8c8c",
-        "gitDecoration.modifiedResourceForeground": "#0087ff",
-        "gitDecoration.stageDeletedResourceForeground": "#c74e39",
-        "gitDecoration.stageModifiedResourceForeground": "#e2c08d",
-        "gitDecoration.submoduleResourceForeground": "#8db9e2",
-        "gitDecoration.untrackedResourceForeground": "#81be24",
-        "editorMarkerNavigation.background": "#0c1633",
-        "editorMarkerNavigationError.background": "#f48771",
-        "editorMarkerNavigationWarning.background": "#cca700",
-        "editorMarkerNavigationInfo.background": "#75beff",
+        "gitDecoration.addedResourceForeground": "#FFFFFF",
+        "gitDecoration.conflictingResourceForeground": "#6C6CC4",
+        "gitDecoration.deletedResourceForeground": "#C74E39",
+        "gitDecoration.ignoredResourceForeground": "#8C8C8C",
+        "gitDecoration.modifiedResourceForeground": "#0087FF",
+        "gitDecoration.stageDeletedResourceForeground": "#C74E39",
+        "gitDecoration.stageModifiedResourceForeground": "#E2C08D",
+        "gitDecoration.submoduleResourceForeground": "#8DB9E2",
+        "gitDecoration.untrackedResourceForeground": "#81BE24",
+        "editorMarkerNavigation.background": "#0C1633",
+        "editorMarkerNavigationError.background": "#F48771",
+        "editorMarkerNavigationWarning.background": "#CCA700",
+        "editorMarkerNavigationInfo.background": "#75BEFF",
         "merge.currentHeaderBackground": "#367366",
         "merge.currentContentBackground": "#27403B",
         "merge.incomingHeaderBackground": "#395F8F",
         "merge.incomingContentBackground": "#28384B",
-        "merge.commonHeaderBackground": "#be2323",
-        "merge.commonContentBackground": "#802424c9",
-        "editorSuggestWidget.background": "#03091e",
+        "merge.commonHeaderBackground": "#BE2323",
+        "merge.commonContentBackground": "#802424C9",
+        "editorSuggestWidget.background": "#03091E",
         "editorSuggestWidget.border": "#454545",
-        "editorSuggestWidget.foreground": "#ffffff",
-        "editorSuggestWidget.highlightForeground": "#0097fb",
-        "editorSuggestWidget.selectedBackground": "#062f4a",
-        "editorHoverWidget.foreground": "#cccccc",
-        "editorHoverWidget.background": "#03091e",
+        "editorSuggestWidget.foreground": "#FFFFFF",
+        "editorSuggestWidget.highlightForeground": "#0097FB",
+        "editorSuggestWidget.selectedBackground": "#062F4A",
+        "editorHoverWidget.foreground": "#CCCCCC",
+        "editorHoverWidget.background": "#03091E",
         "editorHoverWidget.border": "#454545",
-        "peekView.border": "#007acc",
-        "peekViewEditor.background": "#001f33",
-        "peekViewEditorGutter.background": "#001f33",
-        "peekViewEditor.matchHighlightBackground": "#0171ff46",
-        "peekViewEditor.matchHighlightBorder": "#ee931e00",
-        "peekViewResult.background": "#001f33",
-        "peekViewResult.fileForeground": "#ffffff",
-        "peekViewResult.lineForeground": "#bbbbbb",
-        "peekViewResult.matchHighlightBackground": "#0171ff46",
-        "peekViewResult.selectionBackground": "#3399ff33",
-        "peekViewResult.selectionForeground": "#ffffff",
-        "peekViewTitle.background": "#0171ff46",
-        "peekViewTitleDescription.foreground": "#ccccccb3",
-        "peekViewTitleLabel.foreground": "#ffffff",
-        "icon.foreground": "#ececec",
-        "checkbox.background": "#0c1633",
-        "checkbox.foreground": "#cccccc",
+        "peekView.border": "#007ACC",
+        "peekViewEditor.background": "#001F33",
+        "peekViewEditorGutter.background": "#001F33",
+        "peekViewEditor.matchHighlightBackground": "#0171FF46",
+        "peekViewEditor.matchHighlightBorder": "#EE931E00",
+        "peekViewResult.background": "#001F33",
+        "peekViewResult.fileForeground": "#FFFFFF",
+        "peekViewResult.lineForeground": "#BBBBBB",
+        "peekViewResult.matchHighlightBackground": "#0171FF46",
+        "peekViewResult.selectionBackground": "#3399FF33",
+        "peekViewResult.selectionForeground": "#FFFFFF",
+        "peekViewTitle.background": "#0171FF46",
+        "peekViewTitleDescription.foreground": "#CCCCCCB3",
+        "peekViewTitleLabel.foreground": "#FFFFFF",
+        "icon.foreground": "#ECECEC",
+        "checkbox.background": "#0C1633",
+        "checkbox.foreground": "#CCCCCC",
         "checkbox.border": "#00000000",
-        "dropdown.background": "#0c1633",
-        "dropdown.foreground": "#cccccc",
+        "dropdown.background": "#0C1633",
+        "dropdown.foreground": "#CCCCCC",
         "dropdown.border": "#00000000",
-        "minimapGutter.addedBackground": "#587c0c",
-        "minimapGutter.modifiedBackground": "#0c7d9d",
-        "minimapGutter.deletedBackground": "#94151b",
-        "minimap.findMatchHighlight": "#8098b6",
-        "minimap.selectionHighlight": "#264f78",
+        "minimapGutter.addedBackground": "#587C0C",
+        "minimapGutter.modifiedBackground": "#0C7D9D",
+        "minimapGutter.deletedBackground": "#94151B",
+        "minimap.findMatchHighlight": "#8098B6",
+        "minimap.selectionHighlight": "#264F78",
         "minimap.errorHighlight": "#B73A34",
-        "minimap.warningHighlight": "#cca700",
-        "minimap.background": "#03091e",
-        "sideBar.dropBackground": "#383b3d",
-        "editorGroup.emptyBackground": "#03091e",
+        "minimap.warningHighlight": "#CCA700",
+        "minimap.background": "#03091E",
+        "sideBar.dropBackground": "#383B3D",
+        "editorGroup.emptyBackground": "#03091E",
         "panelSection.border": "#80808059",
         "statusBarItem.activeBackground": "#FFFFFF25",
-        "settings.headerForeground": "#ececec",
-        "settings.focusedRowBackground": "#ffffff07",
+        "settings.headerForeground": "#ECECEC",
+        "settings.focusedRowBackground": "#FFFFFF07",
         "walkThrough.embeddedEditorBackground": "#00000050",
-        "breadcrumb.activeSelectionForeground": "#e0e0e0",
-        "editorGutter.commentRangeForeground": "#c5c5c5",
-        "debugExceptionWidget.background": "#151a28",
+        "breadcrumb.activeSelectionForeground": "#E0E0E0",
+        "editorGutter.commentRangeForeground": "#C5C5C5",
+        "debugExceptionWidget.background": "#151A28",
         "debugExceptionWidget.border": "#808080"
     }
 }


### PR DESCRIPTION
## Summary
- normalize color codes in `Revellion Theme-color-theme.json` to 6-digit uppercase hex
- keep alpha channel intact for 8-digit codes

## Testing
- `npm test`